### PR TITLE
added autopilot for public k8s cluster

### DIFF
--- a/gcp/tf/modules/k8s-cluster/main.tf
+++ b/gcp/tf/modules/k8s-cluster/main.tf
@@ -7,20 +7,29 @@ data "google_project" "project" {
 resource "google_container_cluster" "main" {
   name     = var.name
   location = var.location
+# Enable Autopilot mode if specified
+  enable_autopilot = var.enable_autopilot
+
+  # The following configurations only apply to Standard clusters
   # Workload Identity is a feature that allows you to associate a Kubernetes service account with a Google Cloud service account.
   # This is highly recommended, as it allows for more secure and flexible authentication and authorization, for example
   # to manage access to Google Cloud resources from within the cluster.
   # https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
   # https://cloud.google.com/secret-manager/docs/using-other-products#google-kubernetes-engine
-  workload_identity_config {
-    workload_pool = "${data.google_project.project.project_id}.svc.id.goog"
+  dynamic "workload_identity_config" {
+    for_each = var.enable_autopilot ? [] : [1]
+    content {
+      workload_pool = "${data.google_project.project.project_id}.svc.id.goog"
+    }
   }
+
 
   # We want to separately manage the node pool(s) for more control over the nodes.
   # We can't create a cluster with no node pool defined, so we create the smallest possible default
   # node pool and immediately delete it.
-  remove_default_node_pool = true
-  initial_node_count       = 1
+  # Only set these for Standard clusters
+  remove_default_node_pool = var.enable_autopilot ? null : true
+  initial_node_count       = var.enable_autopilot ? null : 1
 
   network    = var.network
   subnetwork = var.subnet
@@ -45,6 +54,7 @@ resource "google_container_cluster" "main" {
 
 # Separately Managed Node Pool
 resource "google_container_node_pool" "primary_nodes" {
+  count    = var.enable_autopilot ? 0 : 1
   name       = google_container_cluster.main.name
   location   = var.location
   cluster    = google_container_cluster.main.name

--- a/gcp/tf/modules/k8s-cluster/variables.tf
+++ b/gcp/tf/modules/k8s-cluster/variables.tf
@@ -32,3 +32,8 @@ variable "machine_type" {
   type        = string
   description = "Machine type for the nodes"
 }
+variable "enable_autopilot" {
+  description = "Enable Autopilot for this cluster"
+  type        = bool
+  default     = false
+}

--- a/gcp/tf/single-cluster-setup/gke/terragrunt.hcl
+++ b/gcp/tf/single-cluster-setup/gke/terragrunt.hcl
@@ -19,11 +19,11 @@ inputs = {
   project_id = local.common_vars.project_id
   project_resource_prefix = local.common_vars.project_resource_prefix
   location = local.common_vars.primary_location
-  enable_autopilot = try(local.common_vars.enable_autopilot, true)
   name = local.effective_cluster_name
   network = dependency.network.outputs.network_name
   subnet = dependency.network.outputs.subnet_names[local.common_vars.primary_location]
   min_node_count = 1
   max_node_count = 3
   machine_type = "e2-standard-2"
+  enable_autopilot = try(local.common_vars.enable_autopilot, true)
 }


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
<p>Implements Autopilot mode for Google Kubernetes Engine (GKE) clusters. Modifies the <code>google_container_cluster</code> resource to conditionally enable Autopilot and adjusts related configurations. Adds an <code>enable_autopilot</code> variable to control this feature, defaulting to false. Updates the <code>terragrunt.hcl</code> file to use this new variable.</p>
    <table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/KoalaOps/infra-template/5?tool=ast&topic=Autopilot+Integration>Autopilot Integration</a>
        </td><td>Implements Autopilot mode for GKE clusters and adjusts configurations accordingly<details><summary>Modified files (3)</summary><ul><li>gcp/tf/modules/k8s-cluster/variables.tf</li>
<li>gcp/tf/single-cluster-setup/gke/terragrunt.hcl</li>
<li>gcp/tf/modules/k8s-cluster/main.tf</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>roylibman</td><td>Squashed-commit-of-the...</td><td>November 28, 2023</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/KoalaOps/infra-template/5?tool=ast&topic=Conditional+Config>Conditional Config</a>
        </td><td>Adds conditional logic to handle differences between Autopilot and Standard clusters<details><summary>Modified files (1)</summary><ul><li>gcp/tf/modules/k8s-cluster/main.tf</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>roylibman</td><td>Squashed-commit-of-the...</td><td>November 28, 2023</td></tr></table></details></td></tr></table>This pull request is reviewed by Baz. Join @hisco and the rest of your team on <a href=https://baz.co/changes/KoalaOps/infra-template/5?tool=ast>(Baz)</a>.
    